### PR TITLE
Update CI workflow to run on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Build and run tests
+        run: ./gradlew --no-daemon clean test build


### PR DESCRIPTION
### Motivation
- Make CI triggers explicit for the `main` branch instead of using a wildcard so pushes and PRs targeting `main` run the workflow.

### Description
- Updated `.github/workflows/ci.yml` to set `on.push.branches: [main]` and `on.pull_request.branches: [main]`, and left the CI job steps intact (checkout, `setup-java`, wrapper validation, and `./gradlew --no-daemon clean test build`).

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'YAML OK'"` which printed `YAML OK`, confirming the workflow file parses successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699038074068832ebd65907c9d808fc8)